### PR TITLE
Add support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Paymill": "lib/"
+            "Services_": "lib/"
         }
     }
 }


### PR DESCRIPTION
This PR adds support for composer (http://getcomposer.org/) incl. autoloading.

The package can then be registered on Packagist (https://packagist.org/) to be easily installed by any project using composer.
