### PR TITLE
Until PHP 5.5, PHP as no way to force TLS 1.0 certificates.

### DIFF
--- a/lib/Services/Paymill/Apiclient/Curl.php
+++ b/lib/Services/Paymill/Apiclient/Curl.php
@@ -105,7 +105,6 @@ class Services_Paymill_Apiclient_Curl implements Services_Paymill_Apiclient_Inte
             CURLOPT_CUSTOMREQUEST => $method,
             CURLOPT_USERAGENT => self::USER_AGENT,
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_SSLVERSION => 3,
             CURLOPT_CAINFO => realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'paymill.crt',
         );
 


### PR DESCRIPTION
Fix #19.
See #15 https://github.com/Paymill/Paymill-PHP/commit/0242d73844a2178415cfd584b742eed6ac72c765 .
