### PR TITLE
Include response code in error responses

### DIFF
--- a/lib/Services/Paymill/Apiclient/Curl.php
+++ b/lib/Services/Paymill/Apiclient/Curl.php
@@ -73,8 +73,8 @@ class Services_Paymill_Apiclient_Curl implements Services_Paymill_Apiclient_Inte
                     $errorMessage = $response['body']['error'];
                 }
                 $responseCode = '';
-                if (isset($response['body']['response_code'])) {
-                    $responseCode = $response['body']['response_code'];
+                if (isset($response['body']['data']['response_code'])) {
+                    $responseCode = $response['body']['data']['response_code'];
                 }
 
                 return array("data" => array(


### PR DESCRIPTION
This change ensures that the response_code is returned in the initial error responses if it's available. The code that was there was failing because it expected the response_code to be available in $response['body']['response_code'] when it's actually in $response['body']['data']['response_code'].
