### PR TITLE
A fix for missing response_code in case of an error.

### DIFF
--- a/lib/Services/Paymill/Apiclient/Curl.php
+++ b/lib/Services/Paymill/Apiclient/Curl.php
@@ -75,8 +75,8 @@ class Services_Paymill_Apiclient_Curl implements Services_Paymill_Apiclient_Inte
                     $errorMessage = $this->_responseArray['body']['error'];
                 }
                 $responseCode = '';
-                if (isset($this->_responseArray['body']['response_code'])) {
-                    $responseCode = $this->_responseArray['body']['response_code'];
+                if (isset($this->_responseArray['body']['data']['response_code'])) {
+                    $responseCode = $this->_responseArray['body']['data']['response_code'];
                 }
 
                 return array("data" => array(


### PR DESCRIPTION
The data structure returned from the server has apparently
changed recently and the current code misses at least this
fix.

Signed-off-by: Jukka Honkela jukka.honkela@singon.com
