### PR TITLE
Extension testing and extra cURL options

### DIFF
--- a/lib/Services/Paymill/Apiclient/Curl.php
+++ b/lib/Services/Paymill/Apiclient/Curl.php
@@ -103,10 +103,10 @@ class Services_Paymill_Apiclient_Curl implements Services_Paymill_Apiclient_Inte
                     $responseCode = $this->_responseArray['body']['data']['response_code'];
                 }
 
-                return array("data" => array(
-                                 "error" => $errorMessage,
-                                 "response_code" => $responseCode,
-                                 "http_status_code" => $httpStatusCode
+                return array('data' => array(
+                                 'error' => $errorMessage,
+                                 'response_code' => $responseCode,
+                                 'http_status_code' => $httpStatusCode
                              ));
             }
 


### PR DESCRIPTION
This patch adds:
1. Better testing of the needed extensions. Assumes PHP 5.0.0 as minimum.
2. Extra cURL options so that we can handle things like proxies and also in the future add extensive logging
    that could include the returned headers, etc.

This is used on the Drupal Commerce integration module.
