### PR TITLE
Bug: Fatal error thrown when array is inserted into Error message

### DIFF
--- a/lib/Paymill/Models/Response/Error.php
+++ b/lib/Paymill/Models/Response/Error.php
@@ -41,6 +41,10 @@ class Error
      */
     public function setErrorMessage($errorMessage)
     {
+		if (is_array($errorMessage)) {
+			$errorMessage = implode(", ", $errorMessage);
+		}
+
         $this->_errorMessage = $errorMessage;
         return $this;
     }

--- a/tests/unit/Paymill/Models/Response/ErrorTest.php
+++ b/tests/unit/Paymill/Models/Response/ErrorTest.php
@@ -47,4 +47,24 @@ class ErrorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($responseCode, $errorModel->getResponseCode());
     }
 
+    /**
+     * Tests the setter and getter of this model
+     * @test
+     */
+    public function setErrorMessageWithArray()
+    {
+        $errorMessage = array("This is a error", "This is an error message again");
+        $httpStatusCode = 200;
+        $responseCode = 20000;
+
+        $errorModel = new Error();
+        $errorModel->setErrorMessage($errorMessage);
+        $errorModel->setHttpStatusCode($httpStatusCode);
+        $errorModel->setResponseCode($responseCode);
+
+        $this->assertEquals($errorMessage[0]. ", " . $errorMessage[1], $errorModel->getErrorMessage());
+        $this->assertEquals($httpStatusCode, $errorModel->getHttpStatusCode());
+        $this->assertEquals($responseCode, $errorModel->getResponseCode());
+    }
+
 }


### PR DESCRIPTION
Adding support for error message being an array, previously it did throw a fatal error when thrown into PaymillException. It should now handle this case gracefully by imploding the array to a string. As the function is told to return a string.
