### PR TITLE
Including version string in one of the files

### DIFF
--- a/lib/Paymill/Request.php
+++ b/lib/Paymill/Request.php
@@ -12,6 +12,7 @@ use Paymill\Services\ResponseHandler;
 
 /**
  * Base
+ * @version 3.0.2
  */
 class Request
 {


### PR DESCRIPTION
Hello,

I'm maintaining a [Drupal module](http://drupal.org/project/uc_paymill) for Paymill integration with Ubercart and have one request: add a version string to one of the library files. Ideally version would be in one of the core files of the library, such as in `Request.php` to make sure the file will always be there.

This is required by a module for managing third party libraries used in Drupal. We have to pass a regex string for recognizing the library version before we can use any of the files in it.

Let me know if any comments/questions and if this works for you.

Thanks.
