### PR TITLE
Checking argument type which must be an array

### DIFF
--- a/lib/Paymill/API/Curl.php
+++ b/lib/Paymill/API/Curl.php
@@ -41,7 +41,7 @@ class Curl extends CommunicationAbstract
      *   Extra cURL options. The array is keyed by the name of the cURL
      *   options.
      */
-    public function __construct($apiKey, $apiEndpoint = 'https://api.paymill.com/v2/', $extracURL = array())
+    public function __construct($apiKey, $apiEndpoint = 'https://api.paymill.com/v2/', array $extracURL = array())
     {
         $this->_apiKey = $apiKey;
         $this->_apiUrl = $apiEndpoint;


### PR DESCRIPTION
The $extracurl parameter needs to be an array with valid curl options to
be used later if needed.

But no check was made about its type. From now on we force its type to
be an array when passes as an argument
