### PR TITLE
#88 greedy autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -2,6 +2,12 @@
 
 function autoload($className)
 {
+    $prefix = 'Paymill\\';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $className, $len) !== 0) {
+        return;
+    }
+
     $className = ltrim($className, "\\");
     $fileName  = '';
     $namespace = '';


### PR DESCRIPTION
Autoloader should load only PAYMILL's classes.
Thanks to @amlet0 suggested in [Issue 88](#88)
