### PR TITLE
Update Curl.php

### DIFF
--- a/lib/Paymill/API/CommunicationAbstract.php
+++ b/lib/Paymill/API/CommunicationAbstract.php
@@ -16,5 +16,5 @@ abstract class CommunicationAbstract
      * @param string $method
      * @return mixed
      */
-    abstract protected function requestApi($action = '', $params = array(), $method = 'POST');
+    abstract public function requestApi($action = '', $params = array(), $method = 'POST');
 }

--- a/lib/Paymill/API/Curl.php
+++ b/lib/Paymill/API/Curl.php
@@ -72,7 +72,7 @@ class Curl extends CommunicationAbstract
 
         // Add extra options to cURL if defined.
         if (!empty($this->_extraOptions)) {
-            $curlOpts = $this->_extraOptions + $curlOpts;
+            $curlOpts = array_merge($curlOpts, $this->_extraOptions);
         }
 
         if ('GET' === $method) {


### PR DESCRIPTION
Otherwise, the pre-defined curl options cannot be overwritten.
And method in AbstractCommunication must be public!