### PR TITLE
Curl opt merge fix

### DIFF
--- a/lib/Paymill/API/Curl.php
+++ b/lib/Paymill/API/Curl.php
@@ -72,7 +72,7 @@ class Curl extends CommunicationAbstract
 
         // Add extra options to cURL if defined.
         if (!empty($this->_extraOptions)) {
-            $curlOpts = array_merge($curlOpts, $this->_extraOptions);
+            $curlOpts = $this->_extraOptions + $curlOpts;
         }
 
         if ('GET' === $method) {

--- a/lib/Paymill/API/Curl.php
+++ b/lib/Paymill/API/Curl.php
@@ -88,7 +88,7 @@ class Curl extends CommunicationAbstract
             $curlOpts[CURLOPT_USERPWD] = $this->_apiKey . ':';
         }
         $curl = curl_init();
-        curl_setopt_array($curl, $curlOpts);
+        $this->_curlOpts($curl, $curlOpts);
         $responseBody = $this->_curlExec($curl);
         $responseInfo = $this->_curlInfo($curl);
 
@@ -117,8 +117,20 @@ class Curl extends CommunicationAbstract
     }
 
     /**
+     * Wraps the curl_setopt_array function call
+     *
+     * @param resource $curl curl resource handle
+     * @param array $curlOpts array containing curl options
+     * @return bool
+     */
+    protected function _curlOpts($curl, array $curlOpts)
+    {
+        return curl_setopt_array($curl, $curlOpts);
+    }
+
+    /**
      * Wrapps the curlExec function call
-     * @param cURL handle success $curl
+     * @param resource $curl cURL handle passed to curl_exec
      * @return mixed
      */
     protected function _curlExec($curl)
@@ -128,7 +140,7 @@ class Curl extends CommunicationAbstract
 
     /**
      * Wrapps the curlInfo function call
-     * @param cURL handle success $curl
+     * @param resource $curl cURL handle passed to curl_getinfo
      * @return mixed
      */
     protected function _curlInfo($curl)
@@ -138,7 +150,7 @@ class Curl extends CommunicationAbstract
 
     /**
      * Wrapps the curlError function call
-     * @param cURL handle success $curl
+     * @param resource $curl cURL handle passed to curl_error
      * @return mixed
      */
     protected function _curlError($curl)

--- a/tests/unit/Paymill/API/CurlTest.php
+++ b/tests/unit/Paymill/API/CurlTest.php
@@ -80,10 +80,11 @@ class CurlTest
 
         $this->_setMockProperties('_curlExec', $responseBody);
         $this->_setMockProperties('_curlInfo', $responseInfo);
+        $that = $this;
         $this->_curlObject->expects($this->once())
             ->method('_curlOpts')
-            ->will($this->returnCallback(function($curl, array $options) use($curlOpts) {
-                $this->assertEquals($curlOpts, $options);
+            ->will($this->returnCallback(function($curl, array $options) use($curlOpts, $that) {
+                $that->assertEquals($curlOpts, $options);
                 return true;
             }));
 

--- a/tests/unit/Paymill/API/CurlTest.php
+++ b/tests/unit/Paymill/API/CurlTest.php
@@ -68,7 +68,7 @@ class CurlTest
         //Desired Results
         $responseBody = array('test' => true);
         $responseInfo = array('http_code' => 200, 'content_type' => 'test');
-        $curlOpts = [
+        $curlOpts = array(
             81    => false,
             10002 => 'https://api.paymill.com/v2.1/',
             19913 => true,
@@ -76,7 +76,7 @@ class CurlTest
             10018 => 'Paymill-php/0.0.2',
             64    => true,
             10005 => 'TestToken:'
-        ];
+        );
 
         $this->_setMockProperties('_curlExec', $responseBody);
         $this->_setMockProperties('_curlInfo', $responseInfo);

--- a/tests/unit/Paymill/API/CurlTest.php
+++ b/tests/unit/Paymill/API/CurlTest.php
@@ -21,7 +21,18 @@ class CurlTest
      */
     protected function setUp()
     {
-        $this->_curlObject = $this->getMock('Paymill\API\Curl', array('_curlExec', '_curlInfo', '_curlError'), array("TestToken"));
+        $constructorArgs = array(
+            'TestToken',
+            'https://api.paymill.com/v2.1/',
+            // add some extra curl options to make sure the merge of default and custom curl options works
+            array(CURLOPT_SSL_VERIFYHOST => false)
+        );
+
+        $this->_curlObject = $this->getMock(
+            'Paymill\API\Curl',
+            array('_curlExec', '_curlInfo', '_curlError', '_curlOpts'),
+            $constructorArgs
+        );
         parent::setUp();
     }
 
@@ -57,9 +68,24 @@ class CurlTest
         //Desired Results
         $responseBody = array('test' => true);
         $responseInfo = array('http_code' => 200, 'content_type' => 'test');
+        $curlOpts = [
+            81    => false,
+            10002 => 'https://api.paymill.com/v2.1/',
+            19913 => true,
+            10036 => 'GET',
+            10018 => 'Paymill-php/0.0.2',
+            64    => true,
+            10005 => 'TestToken:'
+        ];
 
         $this->_setMockProperties('_curlExec', $responseBody);
         $this->_setMockProperties('_curlInfo', $responseInfo);
+        $this->_curlObject->expects($this->once())
+            ->method('_curlOpts')
+            ->will($this->returnCallback(function($curl, array $options) use($curlOpts) {
+                $this->assertEquals($curlOpts, $options);
+                return true;
+            }));
 
         //Testing method using GET
         $result = $this->_curlObject->requestApi("", array(), 'GET');


### PR DESCRIPTION
array_merge does not preserve numeric keys. 
Reverted the commit which introduced the array_merge and added a test to make sure the merge of curl options is covered 