### PR TITLE
Reusable Payments and Client Id for PayPal Checksums

### DIFF
--- a/lib/Paymill/Models/Request/Checksum.php
+++ b/lib/Paymill/Models/Request/Checksum.php
@@ -121,6 +121,11 @@ class Checksum extends Base
      */
     private $_handling_amount;
 
+    /**
+     * Client identifier 
+     * 
+     * @var string $_clientId
+     */
     private $_clientId;
 
     /**
@@ -145,6 +150,13 @@ class Checksum extends Base
         $this->_serviceResource = 'checksums/';
     }
 
+    /**
+     * Sets the identifier of the Client for the transaction
+     * 
+     * @param string $clientId Client identifier
+     * 
+     * @return $this
+     */
     public function setClientId($clientId)
     {
         $this->_clientId = $clientId;
@@ -152,6 +164,11 @@ class Checksum extends Base
         return $this;
     }
 
+    /**
+     * Returns the identifier of the Client associated with the checksum. If no client is available null will be returned
+     * 
+     * @return string
+     */
     public function getClientId()
     {
         return $this->_clientId;

--- a/lib/Paymill/Models/Request/Checksum.php
+++ b/lib/Paymill/Models/Request/Checksum.php
@@ -124,9 +124,9 @@ class Checksum extends Base
     /**
      * Client identifier 
      * 
-     * @var string $_clientId
+     * @var string $_client
      */
-    private $_clientId;
+    private $_client;
 
     /**
      * Reusable payment
@@ -157,9 +157,9 @@ class Checksum extends Base
      * 
      * @return $this
      */
-    public function setClientId($clientId)
+    public function setClient($client)
     {
-        $this->_clientId = $clientId;
+        $this->_client = $client;
 
         return $this;
     }
@@ -169,9 +169,9 @@ class Checksum extends Base
      * 
      * @return string
      */
-    public function getClientId()
+    public function getClient()
     {
-        return $this->_clientId;
+        return $this->_client;
     }
 
     /**
@@ -683,8 +683,8 @@ class Checksum extends Base
                     $parameterArray['reusable_payment_description'] = $this->getReusablePaymentDescription();
                 }
 
-                if($this->getClientId()) {
-                    $parameterArray['client_id'] = $this->getClientId();
+                if($this->getClient()) {
+                    $parameterArray['client'] = $this->getClient();
                 }
 
                 // Unite params:

--- a/lib/Paymill/Models/Request/Checksum.php
+++ b/lib/Paymill/Models/Request/Checksum.php
@@ -122,6 +122,20 @@ class Checksum extends Base
     private $_handling_amount;
 
     /**
+     * Reusable payment
+     *
+     * @var bool $_requireReusablePayment
+     */
+    private $_requireReusablePayment;
+
+    /**
+     * Reusable payment description
+     *
+     * @var string $_reusablePaymentDescription
+     */
+    private $_reusablePaymentDescription;
+
+    /**
      * Creates an instance of the checksum request model
      */
     function __construct()
@@ -516,6 +530,54 @@ class Checksum extends Base
     }
 
     /**
+     * Get require reusable payment
+     *
+     * @return bool
+     */
+    public function getRequireReusablePayment()
+    {
+        return $this->_requireReusablePayment;
+    }
+
+    /**
+     * Set require reusable payment
+     *
+     * @param bool $requireReusablePayment Reusable payment
+     *
+     * @return $this
+     */
+    public function setRequireReusablePayment($requireReusablePayment)
+    {
+        $this->_requireReusablePayment = $requireReusablePayment;
+
+        return $this;
+    }
+
+    /**
+     * Get reusable payment description
+     *
+     * @return string
+     */
+    public function getReusablePaymentDescription()
+    {
+        return $this->_reusablePaymentDescription;
+    }
+
+    /**
+     * Set reusable payment description
+     *
+     * @param string $reusablePaymentDescription Reusable payment description
+     *
+     * @return $this
+     */
+    public function setReusablePaymentDescription($reusablePaymentDescription)
+    {
+        $this->_reusablePaymentDescription = $reusablePaymentDescription;
+
+        return $this;
+    }
+
+    /**
      * Returns an array of parameters customized for the given method name
      *
      * @param string $method
@@ -580,6 +642,14 @@ class Checksum extends Base
 
                 if($this->getHandlingAmount()) {
                     $parameterArray['handling_amount'] = $this->getHandlingAmount();
+                }
+
+                if($this->getRequireReusablePayment()) {
+                    $parameterArray['require_reusable_payment'] = $this->getRequireReusablePayment();
+                }
+
+                if($this->getReusablePaymentDescription()) {
+                    $parameterArray['reusable_payment_description'] = $this->getReusablePaymentDescription();
                 }
 
                 // Unite params:

--- a/tests/unit/Paymill/Models/Request/ChecksumTest.php
+++ b/tests/unit/Paymill/Models/Request/ChecksumTest.php
@@ -88,7 +88,9 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
                 )
             ),
             'shipping_amount' => '50',
-            'handling_amount' => '50'
+            'handling_amount' => '50',
+            'require_reusable_payment' => true,
+            'reusable_payment_description' => 'Paymill Paypal test'
         );
 
         $this->_model
@@ -104,6 +106,8 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
             ->setItems($sample['items'])
             ->setShippingAmount($sample['shipping_amount'])
             ->setHandlingAmount($sample['handling_amount'])
+            ->setRequireReusablePayment($sample['require_reusable_payment'])
+            ->setReusablePaymentDescription($sample['reusable_payment_description'])    
         ;
 
         $this->assertEquals($this->_model->getChecksumType(), $sample['checksum_type']);
@@ -118,7 +122,8 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->_model->getItems(),              $sample['items']);
         $this->assertEquals($this->_model->getShippingAmount(),     $sample['shipping_amount']);
         $this->assertEquals($this->_model->getHandlingAmount(),     $sample['handling_amount']);
-
+        $this->assertEquals($this->_model->getRequireReusablePayment(), $sample['require_reusable_payment']);
+        $this->assertEquals($this->_model->getReusablePaymentDescription(), $sample['reusable_payment_description']);
         return $this->_model;
     }
 
@@ -201,6 +206,8 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
         );
         $parameterArray['shipping_amount'] = '50';
         $parameterArray['handling_amount'] = '50';
+        $parameterArray['require_reusable_payment'] = true;
+        $parameterArray['reusable_payment_description'] = 'Paymill Paypal test';
 
         $creationArray = $model->parameterize("create");
 

--- a/tests/unit/Paymill/Models/Request/ChecksumTest.php
+++ b/tests/unit/Paymill/Models/Request/ChecksumTest.php
@@ -42,6 +42,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
     public function setGetTest()
     {
         $sample = array(
+            'client_id'     => 'client_88a388d9dd48f86c3136',
             'checksum_type' => Checksum::TYPE_PAYPAL,
             'checksum_action' => Checksum::ACTION_TRANSACTION,
             'amount'        => '200',
@@ -94,6 +95,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
         );
 
         $this->_model
+            ->setClientId($sample['client_id'])
             ->setChecksumType($sample['checksum_type'])
             ->setChecksumAction($sample['checksum_action'])
             ->setAmount($sample['amount'])
@@ -110,6 +112,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
             ->setReusablePaymentDescription($sample['reusable_payment_description'])    
         ;
 
+        $this->assertEquals($this->_model->getClientId(), $sample['client_id']);
         $this->assertEquals($this->_model->getChecksumType(), $sample['checksum_type']);
         $this->assertEquals($this->_model->getChecksumAction(), $sample['checksum_action']);
         $this->assertEquals($this->_model->getAmount(),       $sample['amount']);
@@ -159,6 +162,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
     public function parameterizeTestCreate(Checksum $model)
     {
         $parameterArray = array();
+        $parameterArray['client_id'] = 'client_88a388d9dd48f86c3136';
         $parameterArray['checksum_type'] = Checksum::TYPE_PAYPAL;
         $parameterArray['checksum_action'] = Checksum::ACTION_TRANSACTION;
         $parameterArray['amount']        = '200';

--- a/tests/unit/Paymill/Models/Request/ChecksumTest.php
+++ b/tests/unit/Paymill/Models/Request/ChecksumTest.php
@@ -42,7 +42,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
     public function setGetTest()
     {
         $sample = array(
-            'client_id'     => 'client_88a388d9dd48f86c3136',
+            'client'     => 'client_88a388d9dd48f86c3136',
             'checksum_type' => Checksum::TYPE_PAYPAL,
             'checksum_action' => Checksum::ACTION_TRANSACTION,
             'amount'        => '200',
@@ -95,7 +95,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
         );
 
         $this->_model
-            ->setClientId($sample['client_id'])
+            ->setClient($sample['client'])
             ->setChecksumType($sample['checksum_type'])
             ->setChecksumAction($sample['checksum_action'])
             ->setAmount($sample['amount'])
@@ -112,7 +112,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
             ->setReusablePaymentDescription($sample['reusable_payment_description'])    
         ;
 
-        $this->assertEquals($this->_model->getClientId(), $sample['client_id']);
+        $this->assertEquals($this->_model->getClient(), $sample['client']);
         $this->assertEquals($this->_model->getChecksumType(), $sample['checksum_type']);
         $this->assertEquals($this->_model->getChecksumAction(), $sample['checksum_action']);
         $this->assertEquals($this->_model->getAmount(),       $sample['amount']);
@@ -162,7 +162,7 @@ class ChecksumTest extends PHPUnit_Framework_TestCase
     public function parameterizeTestCreate(Checksum $model)
     {
         $parameterArray = array();
-        $parameterArray['client_id'] = 'client_88a388d9dd48f86c3136';
+        $parameterArray['client']        = 'client_88a388d9dd48f86c3136';
         $parameterArray['checksum_type'] = Checksum::TYPE_PAYPAL;
         $parameterArray['checksum_action'] = Checksum::ACTION_TRANSACTION;
         $parameterArray['amount']        = '200';


### PR DESCRIPTION
As per https://developers.paymill.com/guides/paypal/payments

The reusable payment parameters are missing from the API client:
```
-d "require_reusable_payment=true" \
-d "reusable_payment_description=Automatically pay invoices using this account."
```
As well adding the client parameter, and tests